### PR TITLE
Aerogear 3140 - Global kryptowire config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 work
 target
+.idea
+*.iml

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+build:
+	mvn install
+
+test:
+	export MAVEN_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,address=8000,suspend=n" && mvn verify
+
+archive:
+	mvn package
+
+debug:
+	export MAVEN_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,address=8000,suspend=n" && mvn hpi:run

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,11 @@
             <artifactId>symbol-annotation</artifactId>
             <version>1.5</version>
         </dependency>
+        <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <version>1.4.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/aerogear/kryptowire/GlobalConfigurationImpl.java
+++ b/src/main/java/org/aerogear/kryptowire/GlobalConfigurationImpl.java
@@ -1,0 +1,106 @@
+package org.aerogear.kryptowire;
+
+
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.util.FormValidation;
+import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
+import jenkins.model.GlobalConfiguration;
+import org.apache.commons.validator.routines.UrlValidator;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.util.logging.Logger;
+
+@Extension
+public final class GlobalConfigurationImpl extends GlobalConfiguration {
+    private static final Logger LOGGER = Logger.getLogger(GlobalConfigurationImpl.class.getName());
+    private String kwApiKey;
+    private String kwEndpoint;
+
+    public GlobalConfigurationImpl() {
+        load();
+    }
+
+    public boolean isApplicable(Class<? extends AbstractProject> aClass) {
+        return true;
+    }
+
+    @Override
+    public String getGlobalConfigPage() {
+        return super.getGlobalConfigPage();
+    }
+
+    @DataBoundConstructor
+    public GlobalConfigurationImpl(String kwApiKey,String kwEndpoint) {
+        super();
+        load();
+
+        this.setKwApiKey(kwApiKey);
+        this.setKwEndpoint(kwEndpoint);
+    }
+
+    public String getKwApiKey() {
+        return kwApiKey;
+    }
+
+    public void setKwApiKey(String kwApiKey) {
+        this.kwApiKey = kwApiKey;
+    }
+
+    public String getKwEndpoint() {
+        return kwEndpoint;
+    }
+
+    public void setKwEndpoint(String kwEndpoint) {
+        this.kwEndpoint = kwEndpoint;
+    }
+
+    public FormValidation doCheckKwApiKey(@QueryParameter String value) throws IOException, ServletException {
+        if (StringUtils.isEmpty(value)) {
+            LOGGER.info("[info] Missing kryptowire api key field");
+            return FormValidation.error("You must provide a kryptowire api key.");
+        }
+        LOGGER.info("[info] Kryptowire api key validated.");
+        return FormValidation.ok();
+
+    }
+
+    public FormValidation doCheckKwEndpoint(@QueryParameter String value) throws IOException, ServletException {
+        if (StringUtils.isEmpty(value)) {
+            LOGGER.info("[info] Missing kryptowire endpoinf field");
+            return FormValidation.error("You must provide a kryptowire endpoint");
+        }
+
+        String[] schemes = {"http","https"};
+        UrlValidator urlValidator = new UrlValidator(schemes);
+
+        if (!urlValidator.isValid(value)) {
+            LOGGER.info("[info] Failed to validate the kryptowire endpoint as a valid url string.");
+            return FormValidation.error("Invalid kryptowire endpoint format");
+        }
+
+        LOGGER.info("[info] Kryptowire endpoint field validated.");
+        return FormValidation.ok();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Kryptowire Global Config";
+    }
+
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
+        req.bindJSON(this, formData);
+
+        save();
+
+        LOGGER.info("[info] Kryptowire global configuration updated.");
+
+        return super.configure(req, formData);
+    }
+}

--- a/src/main/resources/org/aerogear/kryptowire/GlobalConfigurationImpl/config.jelly
+++ b/src/main/resources/org/aerogear/kryptowire/GlobalConfigurationImpl/config.jelly
@@ -1,0 +1,11 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:section title="Kryptowire">
+        <f:entry title="Kryptowire API key" field="kwApiKey">
+            <f:password />
+        </f:entry>
+        <f:entry title="Kryptowire Endpoint" field="kwEndpoint">
+            <f:textbox />
+        </f:entry>
+    </f:section>
+</j:jelly>

--- a/src/main/resources/org/aerogear/kryptowire/GlobalConfigurationImpl/help-kwApiKey.html
+++ b/src/main/resources/org/aerogear/kryptowire/GlobalConfigurationImpl/help-kwApiKey.html
@@ -1,0 +1,3 @@
+<div>
+    <p>Your kryptowire api key to be used in kryptowire rest api requests.</p>
+</div>

--- a/src/main/resources/org/aerogear/kryptowire/GlobalConfigurationImpl/help-kwEndpoint.html
+++ b/src/main/resources/org/aerogear/kryptowire/GlobalConfigurationImpl/help-kwEndpoint.html
@@ -1,0 +1,3 @@
+<div>
+    <p>Your kryptowire endpoint to be used by its rest api requests.</p>
+</div>

--- a/src/test/java/org/aerogear/kryptowire/GlobalConfigurationImplTest.java
+++ b/src/test/java/org/aerogear/kryptowire/GlobalConfigurationImplTest.java
@@ -1,0 +1,50 @@
+package org.aerogear.kryptowire;
+
+import com.gargoylesoftware.htmlunit.html.HtmlButton;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.*;
+import static org.junit.matchers.JUnitMatchers.*;
+
+import java.util.logging.Logger;
+
+public class GlobalConfigurationImplTest {
+    @Rule public JenkinsRule j = new JenkinsRule();
+    private static Logger log = Logger.getLogger(GlobalConfigurationImplTest.class.getName());
+
+    @Test
+    public void ShouldAssertDevaultValues() throws  Exception {
+        HtmlPage configPage = j.createWebClient().goTo("configure");
+        HtmlForm form = configPage.getFormByName("config");
+        String urlFieldValue = form.getInputByName("_.kwEndpoint").getValueAttribute();
+        String keyFieldValue = form.getInputByName("_.kwApiKey").getValueAttribute();
+        assertEquals("", urlFieldValue);
+        assertEquals("", keyFieldValue);
+    }
+
+    @Test
+    public void ShouldSaveApiToken() throws  Exception {
+        HtmlPage configPage = j.createWebClient().goTo("configure");
+        HtmlForm form = configPage.getFormByName("config");
+        form.getInputByName("_.kwApiKey").setValueAttribute("12345");
+        HtmlButton button = (HtmlButton)configPage.getElementById("yui-gen10-button");
+        button.click();
+        configPage.refresh();
+        assertEquals("12345", form.getInputByName("_.kwApiKey").getValueAttribute());
+    }
+
+    @Test
+    public void ShouldUpdateAnalysisUrl() throws Exception {
+        HtmlPage configPage = j.createWebClient().goTo("configure");
+        HtmlForm form = configPage.getFormByName("config");
+        form.getInputByName("_.kwEndpoint").setValueAttribute("https://myendpoint.kryptowire.com");
+        HtmlButton button = (HtmlButton)configPage.getElementById("yui-gen10-button");
+        button.click();
+        configPage.refresh();
+        assertEquals("https://myendpoint.kryptowire.com", form.getInputByName("_.kwEndpoint").getValueAttribute());
+    }
+}


### PR DESCRIPTION
# Global Plugin Configuration

Jira: [AEROGEAR-3140](https://issues.jboss.org/browse/AEROGEAR-3140)

## Changes:

* Adds global plugin configuration implementation
* Jelly xml for html global config
* Makefile for common maven commands


## Verification:

* Run the tests (`make test`)
* Run the jenkins debug server, navigate to the `/configure` page - there should be a new Kryptowire section
* Change some values (url and api key), stop the debug server and start it again, values should be persisted between server restarts

Using it from java code:

```
GlobalConfigurationImpl config = new GlobalConfigurationImpl();
String endpoint = config.getKwEndpoint();
String token = config.getKwApiKey();
```
