### PR TITLE
Aerogear 3202 add kryptowire submit pipeline step

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <jenkins.version>1.642.3</jenkins.version>
         <java.level>7</java.level>
         <jenkins-test-harness.version>2.13</jenkins-test-harness.version>
+        <workflow.version>2.0</workflow.version>
     </properties>
     <name>Aerogear Kryptowire Jenkins Plugin</name>
     <description>Jenkins plugin that sends a mobile app binary to the kryptowire platform for securitt analysis</description>
@@ -53,12 +54,51 @@
     </pluginRepositories>
 
     <dependencies>
+
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20180130</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.3.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpmime</artifactId>
+            <version>4.3.2</version>
+        </dependency>
+
+        <!-- for workflow support -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
+            <version>${workflow.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.0</version>
-            <optional>true</optional>
+            <version>${workflow.version}</version>
+            <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <version>${workflow.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency> <!-- StepConfigTester -->
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
+            <classifier>tests</classifier>
+            <version>${workflow.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>job-dsl</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,12 @@
     <dependencies>
 
         <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <version>1.6</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20180130</version>

--- a/src/main/java/org/aerogear/kryptowire/KryptowireService.java
+++ b/src/main/java/org/aerogear/kryptowire/KryptowireService.java
@@ -1,0 +1,12 @@
+package org.aerogear.kryptowire;
+
+import hudson.FilePath;
+import org.json.JSONObject;
+
+import java.io.IOException;
+
+public interface KryptowireService {
+
+    JSONObject submit(String platform, FilePath filePath) throws IOException, InterruptedException;
+
+}

--- a/src/main/java/org/aerogear/kryptowire/KryptowireServiceImpl.java
+++ b/src/main/java/org/aerogear/kryptowire/KryptowireServiceImpl.java
@@ -1,0 +1,61 @@
+package org.aerogear.kryptowire;
+
+import hudson.FilePath;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.apache.http.impl.client.BasicResponseHandler;
+import org.apache.http.impl.client.HttpClients;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+public class KryptowireServiceImpl implements KryptowireService {
+
+    private static final Logger logger = Logger.getLogger(KryptowireServiceImpl.class.getName());
+
+    private String apiKey;
+
+    private String apiEndpoint;
+
+    public KryptowireServiceImpl(String apiEndpoint, String apiKey) {
+        if (this.apiEndpoint != null && !this.apiEndpoint.isEmpty() && !this.apiEndpoint.endsWith("/")) {
+            this.apiEndpoint += "/";
+        }
+        this.apiEndpoint = apiEndpoint;
+        this.apiKey = apiKey;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public String getApiEndpoint() {
+        return apiEndpoint;
+    }
+
+    @Override
+    public JSONObject submit(String platform, FilePath filePath) throws IOException, InterruptedException {
+        String endPointUrl = getApiEndpoint() + "/submit";
+
+        HttpPost post = new HttpPost(endPointUrl);
+        MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+        builder.addBinaryBody("app", filePath.read(), ContentType.APPLICATION_OCTET_STREAM, filePath.getName());
+        builder.addTextBody("key", getApiKey());
+        builder.addTextBody("platform", platform);
+
+        HttpEntity entity = builder.build();
+        post.setEntity(entity);
+
+        HttpClient httpclient = HttpClients.createDefault();
+
+        ResponseHandler<String> handler = new BasicResponseHandler();
+        String responseBody = httpclient.execute(post, handler);
+        return new JSONObject(responseBody);
+    }
+
+}

--- a/src/main/java/org/aerogear/kryptowire/workflow/KWSubmitStep.java
+++ b/src/main/java/org/aerogear/kryptowire/workflow/KWSubmitStep.java
@@ -1,0 +1,111 @@
+package org.aerogear.kryptowire.workflow;
+
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.TaskListener;
+import jenkins.model.GlobalConfiguration;
+import org.aerogear.kryptowire.GlobalConfigurationImpl;
+import org.aerogear.kryptowire.KryptowireService;
+import org.aerogear.kryptowire.KryptowireServiceImpl;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.json.JSONObject;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+
+public class KWSubmitStep extends AbstractStepImpl {
+
+    private String platform;
+    private String filePath;
+
+    public String getPlatform() {
+        return platform;
+    }
+
+    @DataBoundSetter
+    public void setPlatform(String platform) {
+        this.platform = platform;
+    }
+
+    public String getFilePath() {
+        return filePath;
+    }
+
+    @DataBoundSetter
+    public void setFilePath(String filePath) {
+        this.filePath = filePath;
+    }
+
+    @DataBoundConstructor
+    public KWSubmitStep(@Nonnull String platform, @Nonnull String filePath) {
+        this.platform = platform;
+        this.filePath = filePath;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+        public DescriptorImpl() {
+            super(KWSubmitExecution.class);
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "kwSubmit";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Submit to Kryptowire";
+        }
+
+    }
+
+    public static class KWSubmitExecution extends AbstractSynchronousNonBlockingStepExecution<Void> {
+
+        private static final long serialVersionUID = 1L;
+
+        @Inject
+        transient KWSubmitStep step;
+
+        @StepContextParameter
+        transient TaskListener listener;
+
+        @Override
+        protected Void run() throws Exception {
+
+            GlobalConfigurationImpl pluginConfig = GlobalConfiguration.all().get(GlobalConfigurationImpl.class);
+
+            String kwEndpoint = pluginConfig.getKwEndpoint();
+            String kwApiKey = pluginConfig.getKwApiKey();
+
+            if(StringUtils.isEmpty(kwEndpoint) || StringUtils.isEmpty(kwApiKey)) {
+                throw new RuntimeException("Kryptowire plugin configuration is not set!");
+            }
+
+            FilePath fp = getContext().get(FilePath.class).child(step.filePath);
+
+            listener.getLogger().println(" --- Kryptowire submit Start ---");
+            listener.getLogger().println("kwSubmit: " + step.platform + " : " + step.filePath);
+            KryptowireService kws = new KryptowireServiceImpl(kwEndpoint,  kwApiKey);
+            JSONObject resp = kws.submit(step.platform, fp);
+            listener.getLogger().println("kw msg: " + resp.get("msg"));
+            listener.getLogger().println("kw uuid: " + resp.get("uuid"));
+            listener.getLogger().println("kw platform: " + resp.get("platform"));
+            listener.getLogger().println("kw package: " + resp.get("package"));
+            listener.getLogger().println("kw version: " + resp.get("version"));
+            listener.getLogger().println("kw hash: " + resp.get("hash"));
+
+            listener.getLogger().println(" --- Kryptowire submit Done ---");
+
+            return null;
+        }
+
+    }
+}

--- a/src/main/resources/org/aerogear/kryptowire/workflow/KWSubmitStep/config.jelly
+++ b/src/main/resources/org/aerogear/kryptowire/workflow/KWSubmitStep/config.jelly
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
+    <f:entry field="platform" title="Platform">
+        <select name="platform">
+            <option value="android">Android</option>
+            <option value="ios">iOS</option>
+        </select>
+    </f:entry>
+    <f:entry field="filePath" title="File Path">
+        <f:textbox/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/org/aerogear/kryptowire/workflow/KWSubmitStep/help-Platform.html
+++ b/src/main/resources/org/aerogear/kryptowire/workflow/KWSubmitStep/help-Platform.html
@@ -1,0 +1,1 @@
+<div>The application platform i.e. android or ios</div>

--- a/src/main/resources/org/aerogear/kryptowire/workflow/KWSubmitStep/help.html
+++ b/src/main/resources/org/aerogear/kryptowire/workflow/KWSubmitStep/help.html
@@ -1,0 +1,8 @@
+<div>
+    Step to send an application binary file to kryptowire.<br>
+
+    Usage Example:<br>
+    <code>
+        kwSubmit filePath: 'app-debug.apk', platform: 'android'
+    </code>
+</div>

--- a/src/main/resources/org/aerogear/kryptowire/workflow/KWSubmitStep/helpFilePath.html
+++ b/src/main/resources/org/aerogear/kryptowire/workflow/KWSubmitStep/helpFilePath.html
@@ -1,0 +1,1 @@
+<div>The path to the application binary file in the workspace</div>


### PR DESCRIPTION
Adds a new pipeline DSL method to submit an application to the globally configured Kryptowire service.

```
kwSubmit filePath: "app-debug.apk", platform: 'android'
```

Jira:

https://issues.jboss.org/browse/AEROGEAR-3202
