### PR TITLE
Ability to pass API Key in the Jenkinsfile using Jenkins Credentials. Legacy Plugin Config still works too.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ User facing docs cane be found [here](./docs).
 
 ## Development Instructions
 
+11/27/2025: Requirements: Maven 3.9.6 and JDK 17
 
 Add or create the following configuration into your maven settings file (usually located at `$HOME/.m2/settings.xml`):
 

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -37,12 +37,71 @@ Params:
 
 * path: your mobile app binary path
 * platform: the application mobile platform (`ios` or `android`)
+* apiKey: your Kryptowire API key, which should be stored as a Jenkins Credential (of type String) - this will ensure the API Key is never printed in logs nor visible in the Jenkins UI
 
 ```groovy
 kwSubmit path: '/path/to/my/app-binary' platform: 'android'
 ```
 
-Sample android (debug build) pipeline script (assumes you have a pre-configured android node):
+Sample 1: Android (debug build) pipeline script with API key provided as a Credential (most secure):
+
+```groovy
+pipeline {
+    agent any // Or specify a specific agent/label
+
+    environment {
+        BUILD_TYPE = 'debug'
+    }
+
+    stages {
+        stage('Checkout') {
+            steps {
+                // Checkout your Android project from SCM
+                git branch: 'main', credentialsId: '', url: 'https://github.com/YOURPROJECT.git'
+            }
+        }
+
+        stage('Clean') {
+            steps {
+                // Clean the project
+                sh './gradlew clean'
+            }
+        }
+
+        stage('Build') {
+            steps {
+                // Build the Android app for the specified BUILD_TYPE
+                sh "echo $ANDROID_HOME"
+                sh "./gradlew assemble${BUILD_TYPE.capitalize()}"
+            }
+        }
+
+        stage('Kryptowire') {
+            steps {
+                withCredentials([string(credentialsId: 'kryptowire-api-key', variable: 'API_KEY')]) {
+                    kwSubmit filePath: "app/build/outputs/apk/debug/app-debug.apk", platform: 'android', apiKey: API_KEY
+                }
+ 
+            }
+        }
+    }
+
+    post {
+        always {
+            // Optional: Clean up workspace after build
+            deleteDir()
+        }
+        success {
+            echo 'Android app build successful!'
+        }
+        failure {
+            echo 'Android app build failed!'
+        }
+    }
+}
+```
+
+Sample 2: Android (debug build) pipeline script with the API key provided in the Kryptowire plugin configuration (insecure - as the key is visible in logs and on the file system.) 
 
 ```groovy
 node('android') {

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <jenkins.version>2.528.1</jenkins.version>
+        <jenkins.version>2.536</jenkins.version>
         <java.level>17</java.level>
         <jenkins-test-harness.version>2520.v0559e74fcf96</jenkins-test-harness.version>
         <workflow.version>2.0</workflow.version>
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
-            <version>1.6</version>
+            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
@@ -170,7 +170,7 @@
                 <version>3.9</version>
                 <configuration>
                     <!-- Optional: configure plugin-specific settings here -->
-                    <jenkinsVersion>2.528.1</jenkinsVersion>
+                    <!--<jenkinsVersion>2.528.1</jenkinsVersion>-->
                     <pluginFirstClassLoader>true</pluginFirstClassLoader>
                     <minimumJavaVersion>17</minimumJavaVersion>
                 </configuration>
@@ -203,6 +203,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.1</version>
             </plugin>
         </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>2.29</version>
-        <relativePath />
-    </parent>
-    <groupId>io.jenkins.plugins</groupId>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>5.28</version>
+    <!--<groupId>io.jenkins.plugins</groupId> 
     <artifactId>kryptowire</artifactId>
-    <version>0.2-SNAPSHOT</version>
-    <packaging>hpi</packaging>
+    <version>0.3-SNAPSHOT</version>  -->
+    <packaging>pom</packaging>
     <properties>
-        <jenkins.version>1.642.3</jenkins.version>
-        <java.level>7</java.level>
+        <jenkins.version>2.361.4</jenkins.version>
+        <java.level>11</java.level>
         <jenkins-test-harness.version>2.13</jenkins-test-harness.version>
         <workflow.version>2.0</workflow.version>
     </properties>
@@ -32,14 +29,13 @@
           <name>Aerogear</name>
         </developer>
     </developers>
-    <!-- Assuming you want to host on @jenkinsci:
-    <url>https://wiki.jenkins.io/display/JENKINS/TODO+Plugin</url>
+    <url>https://github.com/jenkinsci/kryptowire-plugin/tree/master/docs</url>
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    </scm>
-    -->
+        <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+        <tag>${scmTag}</tag>
+        <url>https://github.com/jenkinsci/plugin-pom</url>
+    </scm> 
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1,18 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.jenkins-ci.plugins</groupId>
-    <artifactId>plugin</artifactId>
-    <version>5.28</version>
-    <!--<groupId>io.jenkins.plugins</groupId> 
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>5.28</version>
+        <relativePath />
+    </parent>
+    <groupId>io.jenkins.plugins</groupId> 
     <artifactId>kryptowire</artifactId>
-    <version>0.3-SNAPSHOT</version>  -->
-    <packaging>pom</packaging>
+    <version>0.3-SNAPSHOT</version> 
+    <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.361.4</jenkins.version>
-        <java.level>11</java.level>
-        <jenkins-test-harness.version>2.13</jenkins-test-harness.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <jenkins.version>2.528.1</jenkins.version>
+        <java.level>17</java.level>
+        <jenkins-test-harness.version>2520.v0559e74fcf96</jenkins-test-harness.version>
         <workflow.version>2.0</workflow.version>
+        <hpi-plugin.version>3.9</hpi-plugin.version>
     </properties>
     <name>Kryptowire Plugin</name>
     <description>Jenkins plugin that sends a mobile app binary to the kryptowire platform for security analysis</description>
@@ -49,14 +55,42 @@
         </pluginRepository>
     </pluginRepositories>
 
+<dependencyManagement>
     <dependencies>
+        <dependency>
+            <groupId>io.jenkins.tools.bom</groupId>
+            <artifactId>bom-2.504.x</artifactId>
+            <!-- Latest version goes here -->
+            <version>5577.vea_979d35b_b_ff</version>
+            <scope>import</scope>
+            <type>pom</type>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.htmlunit</groupId>
+            <artifactId>htmlunit</artifactId>
+            <version>3.11.0</version> <!-- Use a specific version like 3.11.0 or newer -->
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version> <!-- Or a more recent stable version -->
+            <scope>provided</scope> <!-- Or compile, depending on your needs -->
+        </dependency>
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
             <version>1.6</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+            <version>12.1.4</version> <!-- Use the version compatible with your Jenkins test harness -->
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
@@ -66,13 +100,13 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.2</version>
+            <version>4.5.14</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpmime</artifactId>
-            <version>4.3.2</version>
+            <version>4.5.14</version>
         </dependency>
 
         <!-- for workflow support -->
@@ -112,11 +146,12 @@
             <artifactId>symbol-annotation</artifactId>
             <version>1.5</version>
         </dependency>
-        <dependency>
+<!--        <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
             <version>1.4.0</version>
         </dependency>
+-->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
@@ -132,8 +167,12 @@
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
                 <extensions>true</extensions>
+                <version>3.9</version>
                 <configuration>
-                  <compatibleSinceVersion>2.0.0</compatibleSinceVersion>
+                    <!-- Optional: configure plugin-specific settings here -->
+                    <jenkinsVersion>2.528.1</jenkinsVersion>
+                    <pluginFirstClassLoader>true</pluginFirstClassLoader>
+                    <minimumJavaVersion>17</minimumJavaVersion>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/org/aerogear/kryptowire/BinaryStatus.java
+++ b/src/main/java/org/aerogear/kryptowire/BinaryStatus.java
@@ -48,7 +48,7 @@ public class BinaryStatus {
     }
 
     public String getSubmittedAt() throws ParseException {
-        SimpleDateFormat dt = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss.SSS");
+        SimpleDateFormat dt = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
         Date d = dt.parse(submittedAt.replace("T", " "));
         return d.toString();
     }

--- a/src/main/java/org/aerogear/kryptowire/GlobalConfigurationImpl.java
+++ b/src/main/java/org/aerogear/kryptowire/GlobalConfigurationImpl.java
@@ -58,7 +58,7 @@ public final class GlobalConfigurationImpl extends GlobalConfiguration {
     public void setKwEndpoint(String kwEndpoint) {
         this.kwEndpoint = kwEndpoint;
     }
-
+/*
     public FormValidation doCheckKwApiKey(@QueryParameter String value) throws IOException, ServletException {
         if (StringUtils.isEmpty(value)) {
             LOGGER.info("[info] Missing kryptowire api key field");
@@ -68,7 +68,7 @@ public final class GlobalConfigurationImpl extends GlobalConfiguration {
         return FormValidation.ok();
 
     }
-
+*/
     public FormValidation doCheckKwEndpoint(@QueryParameter String value) throws IOException, ServletException {
         if (StringUtils.isEmpty(value)) {
             LOGGER.info("[info] Missing kryptowire endpoinf field");

--- a/src/main/java/org/aerogear/kryptowire/GlobalConfigurationImpl.java
+++ b/src/main/java/org/aerogear/kryptowire/GlobalConfigurationImpl.java
@@ -1,6 +1,5 @@
 package org.aerogear.kryptowire;
 
-
 import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.util.FormValidation;

--- a/src/main/java/org/aerogear/kryptowire/workflow/KWSubmitStep.java
+++ b/src/main/java/org/aerogear/kryptowire/workflow/KWSubmitStep.java
@@ -107,12 +107,15 @@ public class KWSubmitStep extends AbstractStepImpl {
             String kwApiKey = step.kwAPIKey;
             listener.getLogger().println(" --- APIKey: " + kwApiKey);
 
-            // LEAVE THIS FOR LEGACY SUPPORT: can specify API Key in the config. This is insecure! 
+            // LEAVE THIS FOR LEGACY SUPPORT: can specify API Key in the config, but this is insecure! 
             if ( kwApiKey == null || kwApiKey.isEmpty() ){
                 kwApiKey = pluginConfig.getKwApiKey();
             }
-            if(StringUtils.isEmpty(kwEndpoint) || StringUtils.isEmpty(kwApiKey)) {
-                throw new RuntimeException("Kryptowire plugin configuration is not set!");
+            if( StringUtils.isEmpty(kwEndpoint) ){
+                throw new RuntimeException("Kryptowire plugin configuration is not correct: Endpoint is not set!");
+            }
+            if ( StringUtils.isEmpty(kwApiKey)) {
+                throw new RuntimeException("Kryptowire plugin configuration is not correct: API Key is not passed in the Jenkinsfile, nor set in the plugin configuration.");
             }
 
             FilePath fp = getContext().get(FilePath.class).child(step.filePath);

--- a/src/main/java/org/aerogear/kryptowire/workflow/KWSubmitStep.java
+++ b/src/main/java/org/aerogear/kryptowire/workflow/KWSubmitStep.java
@@ -26,6 +26,7 @@ public class KWSubmitStep extends AbstractStepImpl {
 
     private String platform;
     private String filePath;
+    private String kwAPIKey;
 
     public String getPlatform() {
         return platform;
@@ -41,8 +42,17 @@ public class KWSubmitStep extends AbstractStepImpl {
     }
 
     @DataBoundSetter
-    public void setFilePath(String filePath) {
+    public void setFilePath( String filePath ){
         this.filePath = filePath;
+    }
+
+    public String getApiKey() {
+        return kwAPIKey;
+    }
+
+    @DataBoundSetter
+    public void setApiKey(String apiKey) {
+        this.kwAPIKey = apiKey;
     }
 
     @DataBoundConstructor
@@ -92,9 +102,15 @@ public class KWSubmitStep extends AbstractStepImpl {
                 throw new RuntimeException("[Error] Could not retrieve global Kryptowire config object.");
             }
 
-            String kwEndpoint = pluginConfig.getKwEndpoint();
-            String kwApiKey = pluginConfig.getKwApiKey();
 
+            String kwEndpoint = pluginConfig.getKwEndpoint();
+            String kwApiKey = step.kwAPIKey;
+            listener.getLogger().println(" --- APIKey: " + kwApiKey);
+
+            // LEAVE THIS FOR LEGACY SUPPORT: can specify API Key in the config. This is insecure! 
+            if ( kwApiKey == null || kwApiKey.isEmpty() ){
+                kwApiKey = pluginConfig.getKwApiKey();
+            }
             if(StringUtils.isEmpty(kwEndpoint) || StringUtils.isEmpty(kwApiKey)) {
                 throw new RuntimeException("Kryptowire plugin configuration is not set!");
             }

--- a/src/test/java/org/aerogear/kryptowire/GlobalConfigurationImplTest.java
+++ b/src/test/java/org/aerogear/kryptowire/GlobalConfigurationImplTest.java
@@ -1,8 +1,8 @@
 package org.aerogear.kryptowire;
 
-import com.gargoylesoftware.htmlunit.html.HtmlButton;
-import com.gargoylesoftware.htmlunit.html.HtmlForm;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.htmlunit.html.HtmlButton;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlPage;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;

--- a/src/test/java/org/aerogear/kryptowire/org/aerogear/kryptowire/integration/KWSubmitStepTest.java
+++ b/src/test/java/org/aerogear/kryptowire/org/aerogear/kryptowire/integration/KWSubmitStepTest.java
@@ -17,8 +17,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.jenkinsci.plugins.workflow.job.*;
-import org.omg.CORBA.Environment;
-import sun.net.www.http.HttpClient;
+//import org.omg.CORBA.Environment;
+//import sun.net.www.http.HttpClient;
 
 public class KWSubmitStepTest extends Mockito {
     @ClassRule public static BuildWatcher bw = new BuildWatcher();


### PR DESCRIPTION
## What
- Updated pom.xml for modern Jenkins target using JDK 17 and Maven 3.9.6
- Added an option to specify the API key as a Credentials entry, which is properly secured and masked. (but left the legacy code in place so can still work even if not specifying with Credentials)
- Updated plugin docs and error reporting for the plugin

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. From Jenkins Config -> Credentials add a credential, type String (Secret Text) with the ID kryptowire-api-key and global scope
2. modify the Jenkinsfile to call kwSubmit like this:
      stage('Kryptowire') {
            steps {
                withCredentials([string(credentialsId: 'kryptowire-api-key', variable: 'API_KEY')]) {
                    kwSubmit filePath: "app/build/outputs/apk/debug/app-debug.apk", platform: 'android', apiKey: API_KEY
                }
            }
        }
3. Blank out the API key from the Kryptowire Plugin Configuration screen. (or change it to an invalid key)
4. Run the build and verify it works


